### PR TITLE
官方文档对math.random的参数描述的bug

### DIFF
--- a/manual.html
+++ b/manual.html
@@ -8267,7 +8267,7 @@ UTF-8 字符的个数。
 当以两个整数 <code>m</code> 与 <code>n</code> 调用时，
 <code>math.random</code> 返回一个 <em>[m, n]</em> 区间
 内一致分布的整数伪随机数。
-（值 <em>n-m</em> 不能是负数（官方文档原文描述m-n cannot be negative有误），且必须在 Lua 整数的表示范围内。）
+（值 <em>n-m</em> 不能是负数，且必须在 Lua 整数的表示范围内。）
 调用 <code>math.random(n)</code> 等价于 <code>math.random(1,n)</code>。
 
 

--- a/manual.html
+++ b/manual.html
@@ -8267,7 +8267,7 @@ UTF-8 字符的个数。
 当以两个整数 <code>m</code> 与 <code>n</code> 调用时，
 <code>math.random</code> 返回一个 <em>[m, n]</em> 区间
 内一致分布的整数伪随机数。
-（值 <em>n-m</em> 不能是负数（官方文档原文描述有误），且必须在 Lua 整数的表示范围内。）
+（值 <em>n-m</em> 不能是负数（官方文档原文描述m-n cannot be negative有误），且必须在 Lua 整数的表示范围内。）
 调用 <code>math.random(n)</code> 等价于 <code>math.random(1,n)</code>。
 
 

--- a/manual.html
+++ b/manual.html
@@ -8267,7 +8267,7 @@ UTF-8 字符的个数。
 当以两个整数 <code>m</code> 与 <code>n</code> 调用时，
 <code>math.random</code> 返回一个 <em>[m, n]</em> 区间
 内一致分布的整数伪随机数。
-（值 <em>m-n</em> 不能是负数，且必须在 Lua 整数的表示范围内。）
+（值 <em>n-m</em> 不能是负数（官方文档原文描述有误），且必须在 Lua 整数的表示范围内。）
 调用 <code>math.random(n)</code> 等价于 <code>math.random(1,n)</code>。
 
 


### PR DESCRIPTION
官方文档对math.random的参数m，n描述为m-n不能为负数，实际应该为n-m不能为负数
